### PR TITLE
Add cookie-based auth endpoints

### DIFF
--- a/src/main/java/com/TingTing/config/SecurityConfig.java
+++ b/src/main/java/com/TingTing/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**", "/login", "/signup", "/ws/**").permitAll()
+                        .requestMatchers("/api/auth/**", "/auth/**", "/login", "/signup", "/ws/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/TingTing/controller/SignController.java
+++ b/src/main/java/com/TingTing/controller/SignController.java
@@ -1,8 +1,14 @@
 package com.TingTing.controller;
 
+import com.TingTing.dto.SignInRequest;
+import com.TingTing.dto.SignUpRequest;
+import com.TingTing.dto.TokenResponse;
+import com.TingTing.entity.User;
 import com.TingTing.service.SignService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,7 +25,15 @@ public class SignController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<TokenResponse> signin(@RequestBody SignInRequest dto) {
-        return ResponseEntity.ok(authService.logIn(dto));
+    public ResponseEntity<TokenResponse> signin(@RequestBody SignInRequest dto,
+                                                HttpServletResponse response) {
+        return ResponseEntity.ok(authService.logIn(dto, response));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal User user,
+                                       HttpServletResponse response) {
+        authService.logOut(user, response);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/TingTing/controller/UserController.java
+++ b/src/main/java/com/TingTing/controller/UserController.java
@@ -4,6 +4,7 @@ import com.TingTing.dto.UserDTO;
 import com.TingTing.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import com.TingTing.entity.User;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,16 +17,16 @@ public class UserController {
 
     // ✅ 내 정보 조회 (JWT 기반)
     @GetMapping("/me")
-    public ResponseEntity<UserDTO> getMyProfile(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        UserDTO user = userService.getUserProfile(userDetails.getUser().getUsIdx());
-        return ResponseEntity.ok(user);
+    public ResponseEntity<UserDTO> getMyProfile(@AuthenticationPrincipal User user) {
+        UserDTO dto = userService.getUserProfile(user.getUsIdx());
+        return ResponseEntity.ok(dto);
     }
 
     // ✅ 닉네임 수정
     @PutMapping("/me/nickname")
-    public ResponseEntity<Void> updateNickname(@AuthenticationPrincipal CustomUserDetails userDetails,
+    public ResponseEntity<Void> updateNickname(@AuthenticationPrincipal User user,
                                                @RequestParam("nickname") String nickname) {
-        userService.updateNickname(userDetails.getUser().getUsIdx(), nickname);
+        userService.updateNickname(user.getUsIdx(), nickname);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/TingTing/dto/TokenResponse.java
+++ b/src/main/java/com/TingTing/dto/TokenResponse.java
@@ -6,6 +6,5 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class TokenResponse {
-    private String accessToken;
     private String nickname;
 }

--- a/src/main/java/com/TingTing/entity/User.java
+++ b/src/main/java/com/TingTing/entity/User.java
@@ -43,4 +43,8 @@ public class User {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority("ROLE_USER"));
     }
+
+    public void updateNickname(String nickname) {
+        this.usNickname = nickname;
+    }
 }

--- a/src/main/java/com/TingTing/mapper/UserMapper.java
+++ b/src/main/java/com/TingTing/mapper/UserMapper.java
@@ -1,0 +1,18 @@
+package com.TingTing.mapper;
+
+import com.TingTing.dto.UserDTO;
+import com.TingTing.entity.User;
+
+public class UserMapper {
+    public static UserDTO toDTO(User user) {
+        if (user == null) return null;
+        return UserDTO.builder()
+                .usIdx(user.getUsIdx())
+                .usEmail(user.getUsEmail())
+                .usPw(user.getUsPw())
+                .usNickname(user.getUsNickname())
+                .usProfileImg(user.getUsProfileImg())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/TingTing/service/SignService.java
+++ b/src/main/java/com/TingTing/service/SignService.java
@@ -1,0 +1,84 @@
+package com.TingTing.service;
+
+import com.TingTing.dto.SignInRequest;
+import com.TingTing.dto.SignUpRequest;
+import com.TingTing.dto.TokenResponse;
+import com.TingTing.entity.User;
+import com.TingTing.repository.UserRepository;
+import com.TingTing.util.JwtTokenProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SignService {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenService refreshTokenService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private final long ACCESS_EXPIRE = 1000 * 60 * 60; // 1h
+    private final long REFRESH_EXPIRE = 1000 * 60 * 60 * 24 * 7; //7d
+
+    public void signUp(SignUpRequest dto) {
+        if (userRepository.existsByUsEmail(dto.getEmail())) {
+            throw new RuntimeException("Email already exists");
+        }
+        if (userRepository.existsByUsNickname(dto.getNickname())) {
+            throw new RuntimeException("Nickname already exists");
+        }
+
+        User user = User.builder()
+                .usEmail(dto.getEmail())
+                .usPw(dto.getPassword())
+                .usNickname(dto.getNickname())
+                .build();
+        userRepository.save(user);
+    }
+
+    public TokenResponse logIn(SignInRequest dto, HttpServletResponse response) {
+        User user = userRepository.findByUsEmail(dto.getEmail())
+                .orElseThrow(() -> new RuntimeException("Invalid credentials"));
+
+        if (!user.getUsPw().equals(dto.getPassword())) {
+            throw new RuntimeException("Invalid credentials");
+        }
+
+        String accessToken = jwtTokenProvider.generateAccessToken(user.getUsEmail());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUsEmail());
+
+        refreshTokenService.saveOrUpdate(user.getUsEmail(), refreshToken, REFRESH_EXPIRE);
+
+        Cookie ac = new Cookie("accessToken", accessToken);
+        ac.setHttpOnly(true);
+        ac.setPath("/");
+        ac.setMaxAge((int) (ACCESS_EXPIRE / 1000));
+        response.addCookie(ac);
+
+        Cookie rc = new Cookie("refreshToken", refreshToken);
+        rc.setHttpOnly(true);
+        rc.setPath("/");
+        rc.setMaxAge((int) (REFRESH_EXPIRE / 1000));
+        response.addCookie(rc);
+
+        return new TokenResponse(user.getUsNickname());
+    }
+
+    public void logOut(User user, HttpServletResponse response) {
+        refreshTokenService.delete(user.getUsEmail());
+
+        Cookie ac = new Cookie("accessToken", null);
+        ac.setPath("/");
+        ac.setMaxAge(0);
+        response.addCookie(ac);
+
+        Cookie rc = new Cookie("refreshToken", null);
+        rc.setPath("/");
+        rc.setMaxAge(0);
+        response.addCookie(rc);
+    }
+}

--- a/src/main/java/com/TingTing/service/UserService.java
+++ b/src/main/java/com/TingTing/service/UserService.java
@@ -1,0 +1,30 @@
+package com.TingTing.service;
+
+import com.TingTing.dto.UserDTO;
+import com.TingTing.entity.User;
+import com.TingTing.mapper.UserMapper;
+import com.TingTing.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserDTO getUserProfile(int usIdx) {
+        return userRepository.findById(usIdx)
+                .map(UserMapper::toDTO)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+    }
+
+    public void updateNickname(int usIdx, String nickname) {
+        User user = userRepository.findById(usIdx)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        user.updateNickname(nickname);
+        userRepository.save(user);
+    }
+}


### PR DESCRIPTION
## Summary
- deliver login tokens via HTTP-only cookies only
- add logout endpoint that clears cookies and refresh token
- adjust UserController to use `User` principal

## Testing
- `./gradlew test -q` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68849d4d83a0833392d0f9a8212a0066